### PR TITLE
udevmand: fix segmentation fault during iface flushing

### DIFF
--- a/netdev.c
+++ b/netdev.c
@@ -138,8 +138,9 @@ iface_flush(void)
 		if (!iface->alive) {
 			avl_delete(&iface_tree, &iface->avl);
 			free(iface);
+		} else {
+			iface->alive = 0;
 		}
-		iface->alive = 0;
 	}
 }
 


### PR DESCRIPTION
Segmentation fault happens when accessing the alive field after the iface structure has been freed, in the case where alive is 0